### PR TITLE
Configure plugin to be enabled on anonymous pages

### DIFF
--- a/kibana.json
+++ b/kibana.json
@@ -9,6 +9,7 @@
   "description": "Customize Kibana CSS",
   "server": false,
   "ui": true,
+  "enabledOnAnonymousPages": true,
   "requiredPlugins": [],
   "optionalPlugins": []
 }


### PR DESCRIPTION
Fixes the plugin definition to load on anonymous pages as well (i.e. login page).

Resolves https://github.com/lizozom/custom-kibana-logo/issues/5
Resovles https://github.com/lizozom/custom-kibana-logo/issues/4
