### PR TITLE
Customise fonts and font sizes

### DIFF
--- a/public/index.ts
+++ b/public/index.ts
@@ -4,6 +4,7 @@ import './scss/login.scss';
 import './scss/dashboard.scss';
 import './scss/home.scss';
 import './scss/space_selector.scss';
+import './scss/fonts.scss';
 
 import { CustomKibanaLogoPlugin } from './plugin';
 

--- a/public/scss/dashboard.scss
+++ b/public/scss/dashboard.scss
@@ -8,5 +8,9 @@
         .euiPanel.euiPanel--plain {
             background: #eff3fb;
         }
+
+        .embPanel__titleText {
+            font-size: 16px;
+        }
     }
  }

--- a/public/scss/fonts.scss
+++ b/public/scss/fonts.scss
@@ -1,0 +1,5 @@
+@import url('https://fonts.cdnfonts.com/css/lato');
+
+body {
+    font-family: 'Lato', sans-serif;
+}


### PR DESCRIPTION
A popular ask of Kibana is to customise the fonts and font sizes.
https://github.com/elastic/kibana/issues/2207

This PR shows how to change the fonts and font sizes.

Note that if you use a custom font, you might need to add the font url to the `Content Security Policy`.
This can be done in the `kibana.yml`, by setting:

```
csp.style_src: ["FONT_BASE_URL"]
csp.font_src: ["FONT_BASE_URL"]
```